### PR TITLE
Avoid of multiple definition errors

### DIFF
--- a/tft_lib.c
+++ b/tft_lib.c
@@ -1,3 +1,5 @@
+#define __TFT_LIB_C__
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>

--- a/tft_lib.h
+++ b/tft_lib.h
@@ -1,5 +1,10 @@
 #ifndef __TFT_LIB_H__
 #define __TFT_LIB_H__
+	#ifndef __TFT_LIB_C__
+		#define DECLARE extern
+	#else
+		#define DECLARE 
+	#endif
 
 #include "fontx.h"
 
@@ -63,13 +68,13 @@ typedef struct {
 } TFT_t;
 
 // Driver dependent function
-void (*DrawPixel)(TFT_t * dev, uint16_t x, uint16_t y, uint16_t color);
-void (*DrawMultiPixels)(TFT_t * dev, uint16_t x, uint16_t y, uint16_t size, uint16_t * colors);
-void (*DrawFillRect)(TFT_t * dev, uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
-void (*DisplayOff)(TFT_t * dev);
-void (*DisplayOn)(TFT_t * dev);
-void (*InversionOff)(TFT_t * dev);
-void (*InversionOn)(TFT_t * dev);
+DECLARE void (*DrawPixel)(TFT_t * dev, uint16_t x, uint16_t y, uint16_t color);
+DECLARE void (*DrawMultiPixels)(TFT_t * dev, uint16_t x, uint16_t y, uint16_t size, uint16_t * colors);
+DECLARE void (*DrawFillRect)(TFT_t * dev, uint16_t x1, uint16_t y1, uint16_t x2, uint16_t y2, uint16_t color);
+DECLARE void (*DisplayOff)(TFT_t * dev);
+DECLARE void (*DisplayOn)(TFT_t * dev);
+DECLARE void (*InversionOff)(TFT_t * dev);
+DECLARE void (*InversionOn)(TFT_t * dev);
 
 // Global function
 void lcdDelay(int ms);


### PR DESCRIPTION
We do #include tft_lib.h throughout the program, and the tft.h file has its own protection against multiple inclusion: #ifndef \_\_TFT_LIB_H__ . However, this protection fails when we first include the tft_lib.h file when building the driver.a library and then try to build the main program that also #includes tft_lib.h along with the library driver.a .
Global vars (*DrawPixel ... *InversionOn) which we declare in this tft_lib.h file should be declared only once as "global vars" . And additionally we can include them as =external= variables in as many files as we want.
The *.c file name, consonant with the name of the tft_lib.h, I mean tft_lib.c, suggests that for any set of modules in the final program, where the tft_lib.h file is included, this set will always have the tft_lib.c module. So, we do declare global vars when we include tht_lib.h to tft_lib.c and do extern vars declarations when we include tft_lib.h to other *.c files.